### PR TITLE
add github action to build images

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/build-push-images-latest.yaml
+++ b/.github/workflows/build-push-images-latest.yaml
@@ -1,0 +1,52 @@
+name: latest-build
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+jobs:
+  docker-builder:
+    # Only push if PR happens in the same repo
+    if: github.event.pull_request.base.repo.url == github.event.pull_request.head.repo.url
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Docker meta
+        id: docker_meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ secrets.DOCKERHUB_REPO }}/hugo-watcher
+          tags: |
+            type=semver,pattern=\d.\d.\d
+            type=ref,event=branch
+            type=ref,event=pr
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
+          cache-from: |
+            type=gha,scope=test
+            type=gha,scope=prod
+          cache-to: type=gha,scope=prod
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/build-push-images-release.yaml
+++ b/.github/workflows/build-push-images-release.yaml
@@ -65,7 +65,7 @@ jobs:
         with:
           images: ${{ secrets.DOCKERHUB_REPO }}/hugo-watcher
           tags: |
-            type=semver,pattern=\d.\d.\d
+            type=semver
             type=ref,event=branch
             type=ref,event=pr
       - name: Build and push

--- a/.github/workflows/build-push-images-release.yaml
+++ b/.github/workflows/build-push-images-release.yaml
@@ -65,7 +65,7 @@ jobs:
         with:
           images: ${{ secrets.DOCKERHUB_REPO }}/hugo-watcher
           tags: |
-            type=semver
+            type=semver,pattern={{version}}
             type=ref,event=branch
             type=ref,event=pr
       - name: Build and push

--- a/.github/workflows/build-push-images-release.yaml
+++ b/.github/workflows/build-push-images-release.yaml
@@ -1,0 +1,84 @@
+name: release-build
+on:
+  workflow_dispatch:
+    inputs:
+      tags:
+        description: 'Git tag to use'
+  release:
+    types:
+      - released
+  push:
+    tags:
+      - '*.*.*.'
+      - 'v*.*.*.'
+jobs:
+  docker-builder-run-on-tag:
+    if: ${{ github.event.inputs.tags }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.tags }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKERHUB_REPO }}/hugo-watcher:${{ github.event.inputs.tags }}
+          cache-from: type=gha,scope=prod
+          cache-to: type=gha,scope=prod
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}
+
+  docker-builder-run-on-tag-release:
+    if: ${{ !github.event.inputs.tags }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Docker meta
+        id: docker_meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ secrets.DOCKERHUB_REPO }}/hugo-watcher
+          tags: |
+            type=semver,pattern=\d.\d.\d
+            type=ref,event=branch
+            type=ref,event=pr
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
+          cache-from: type=gha,scope=prod
+          cache-to: type=gha,scope=prod
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
# How to use

This action follows the standard in https://github.com/kartoza/prj.app

In the repository settings, create 3 new Repository secrets (currently I have no access to the settings page):

```
DOCKERHUB_REPO=kartoza
DOCKERHUB_USERNAME=dockerkartozabot
DOCKERHUB_PASSWORD=<get it from Kartoza secret document>
```


![image](https://user-images.githubusercontent.com/831865/130491405-dcc7adff-e03c-4f4a-9f80-f54dcdabb8c3.png)

- The image will be built automatically on branch push (currently activated for `main` branch). Resulting tag will be something like `kartoza/hugo-watcher:main`
- The image will be autobuild on Git Tagging/Release, as long as the tag follow Semver convention https://semver.org. The resulting tag will be `kartoza/hugo-watcher:{{tag}}`
- The image will be autobuild on internal PR (same branch in the same repo, due to the security restriction for the secrets), so that it can be tried before merging. The resulting tag will be like kartoza/hugo-watcher:pr-1
- The image can be custom build, for specific tag. Create the git tag first, then execute the `release-build` action manually and specify the tag name. The docker image will use the same tag.